### PR TITLE
Fixed the HAS and HAS which caused a warning from New Versions of MM

### DIFF
--- a/GameData/SPEngine/TestFlight_techTransfer.cfg
+++ b/GameData/SPEngine/TestFlight_techTransfer.cfg
@@ -1,6 +1,6 @@
 // Set 25% generation penalties for SPEngines' TF techTransfer.
 // These are steeper than the (default) 5% used by RO, but then we get to share data between all the engines in a family (and techTransfer from some corresponding non-proc engines, too) so hopefully the two balance out a bit.
-@PART[*]:HAS[@MODULE[ModuleSPEngine]]:HAS[@MODULE[TestFlightCore]]:AFTER[zTestFlight]
+@PART[*]:HAS[@MODULE[ModuleSPEngine] , @MODULE[TestFlightCore]]:AFTER[zTestFlight]
 {
 	@MODULE[TestFlightCore]
 	{


### PR DESCRIPTION
It was only looking at the first HAS and was not taking the TestFlightCore into account.